### PR TITLE
Add test correctness::compare_negative_and_negative

### DIFF
--- a/tests.cpp
+++ b/tests.cpp
@@ -177,6 +177,16 @@ TEST(correctness, compare_zero_and_minus_zero) {
   EXPECT_TRUE(a == b);
 }
 
+TEST(correctness, compare_negative_and_negative) {
+  big_integer a = -100;
+  big_integer b = -100;
+
+  EXPECT_FALSE(a < b);
+  EXPECT_FALSE(a > b);
+  EXPECT_TRUE(a >= b);
+  EXPECT_TRUE(a >= b);
+}
+
 TEST(correctness, add) {
   big_integer a = 5;
   big_integer b = 20;

--- a/tests.cpp
+++ b/tests.cpp
@@ -184,7 +184,7 @@ TEST(correctness, compare_negative_and_negative) {
   EXPECT_FALSE(a < b);
   EXPECT_FALSE(a > b);
   EXPECT_TRUE(a >= b);
-  EXPECT_TRUE(a >= b);
+  EXPECT_TRUE(a <= b);
 }
 
 TEST(correctness, add) {


### PR DESCRIPTION
Если для сравнения отрицательных чисел использовать xor со знаком:
`negative ^ abs_compare(a, b)`,
то `<` станет `<=`, а `<=` станет `<`.

Сейчас тесты проходят с такой реализацией.